### PR TITLE
Inconsistent Styling in Archives Sidebar

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Class names were snake_cased as opposed to kebab-cased.

```
"sidebar_title" => "sidebar-title"
"sidebar_body" => "sidebar-body"
```

Adjusting class names resolves the issue.